### PR TITLE
Edited index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
             PS4 Pro for $149 (Trade of PS4 Slim + 2 Games Required) @ EB Games
         </h2>
         <p>
-            You are able to trade in any Playstation console for this dead (besides the pro), If you trade in the OG PS4, it will cost $179, and $149 for PS4 slim. This deal only lasts for a week.
+            You are able to trade in any Playstation console for this deal (besides the pro), If you trade in the OG PS4, it will cost $179, and $149 for PS4 slim. This deal only lasts for a week.
     </div>
     <div id="deals">
         <h2>

--- a/index.html
+++ b/index.html
@@ -62,10 +62,10 @@
     </div>
     <div id="deals">
         <h2>
-            Deal 4
+            PS4 Pro for $149 (Trade of PS4 Slim + 2 Games Required) @ EB Games
         </h2>
         <p>
-            Let's creating some deals
+            You are able to trade in any Playstation console for this dead (besides the pro), If you trade in the OG PS4, it will cost $179, and $149 for PS4 slim. This deal only lasts for a week.
     </div>
     <div id="deals">
         <h2>


### PR DESCRIPTION
I've added another deal to the ongoing list. The deal I added was the one explaining a new deal EB Games had struct with their customers. The deal was if you traded in a PlayStation 4 slim for $149 and if you also traded in two games with that, you could get yourself a PlayStation 4 pro. I also added a little extra detail explaining how someone could also trade in their OG PlayStation 4 with two games for $30 more than the slim. 